### PR TITLE
[Suggestion]Disabled vertical moving if not zoomed

### DIFF
--- a/lib/ImageViewer.tsx
+++ b/lib/ImageViewer.tsx
@@ -141,8 +141,6 @@ export default function ImageViewer({
 				} else {
 					translateY.value = possibleNewTranslateY;
 				}
-			} else {
-				translateY.value = savedTranslateY.value + event.translationY;
 			}
 		})
 		.onEnd((event) => {


### PR DESCRIPTION
I think it should not move vertically if it is not zoomed same like horizontal! only check scale.value > 1
other wise no effect