### PR TITLE
Add swipe down to close and improve transitions on swipe to close

### DIFF
--- a/lib/ImageViewer.tsx
+++ b/lib/ImageViewer.tsx
@@ -147,9 +147,12 @@ export default function ImageViewer({
 		})
 		.onEnd((event) => {
 			if (scale.value === 1) {
+                const topBoundary = -finalHeight - dimensions.height;
 				if (event.translationY < -50) {
 					if (event.velocityY < -2000 || event.translationY < -200) {
-						runOnJS(onRequestClose)();
+                        translateY.value = withTiming(topBoundary, { duration: 200 }, () => {
+                            runOnJS(onRequestClose)();
+                        });
 
 						return;
 					}

--- a/lib/ImageViewer.tsx
+++ b/lib/ImageViewer.tsx
@@ -148,6 +148,8 @@ export default function ImageViewer({
 		.onEnd((event) => {
 			if (scale.value === 1) {
                 const topBoundary = -finalHeight - dimensions.height;
+                const bottomBoundary = dimensions.height + finalHeight;
+
 				if (event.translationY < -50) {
 					if (event.velocityY < -2000 || event.translationY < -200) {
                         translateY.value = withTiming(topBoundary, { duration: 200 }, () => {
@@ -157,6 +159,15 @@ export default function ImageViewer({
 						return;
 					}
 				}
+
+                if (event.translationY > 50) {
+                    if (event.velocityY > 2000 || event.translationY > 200) {
+                        translateY.value = withTiming(bottomBoundary, { duration: 200 }, () => {
+                            runOnJS(onRequestClose)();
+                        });
+                        return;
+                    }
+                }
 
 				translateY.value = withTiming(0);
 				translateX.value = withTiming(0);


### PR DESCRIPTION
1. Added functionality to swipe down to close image
2. When swiping to close an image, added a transition such that the image slides fully out of the screen before closing rather than immediately disappearing.